### PR TITLE
US1484, TA3435: Integrate with our build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@ pru_sw/example_apps/*/obj
 pru_sw/example_apps/bin/
 
 *.pdb
+*.so
+*.a
+
+debug
+release

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,7 @@ include $(BUILD_DIR)/makefile.d/base.mk
 
 ROOTDIR = .
 TARGET = libpru-driver
-CROSS_COMPILE?=arm-linux-gnueabihf-
-PREFIX?=/usr/local
+CROSS_COMPILE ?= arm-linux-gnueabihf-
 
 CC = $(CROSS_COMPILE)gcc
 AR = $(CROSS_COMPILE)ar
@@ -13,8 +12,8 @@ INCLUDEDIR = ./pru_sw/app_loader/include
 C_FLAGS += -I. -Wall -I$(INCLUDEDIR)
 
 COMPILE.c = $(CC) $(C_FLAGS) $(CPP_FLAGS) -c
-AR.c	  = $(AR) rc
-LINK.c	  = $(CC) -shared
+AR.c = $(AR) rc
+LINK.c = $(CC) -shared
 
 DBGTARGET = $(OUTPUT_DIR)/$(TARGET)d.a
 RELTARGET = $(OUTPUT_DIR)/$(TARGET).a
@@ -37,15 +36,15 @@ PIC_RELOBJFILES = $(SOURCES:%.c=$(OUTPUT_DIR)/release/%_PIC.o)
 
 .PHONY: clean debug release sodebug sorelease install
 
-all:	debug release sodebug sorelease
+all: debug release sodebug sorelease
 
-release:	$(RELTARGET)
+release: $(RELTARGET)
 
-sorelease:	$(SORELTARGET)
+sorelease: $(SORELTARGET)
 
-sodebug:	$(SODBGTARGET)
+sodebug: $(SODBGTARGET)
 
-debug:		$(DBGTARGET)
+debug: $(DBGTARGET)
 
 $(OUTPUT_DIR):
 	$(VERBOSE)mkdir -p $(OUTPUT_DIR)/release/pru_sw/app_loader/interface
@@ -55,7 +54,7 @@ $(RELTARGET): $(RELOBJFILES)
 	@mkdir -p $(ROOTDIR)/lib
 	$(AR.c) $@ $(RELOBJFILES)
 
-$(SORELTARGET):	$(PIC_RELOBJFILES)
+$(SORELTARGET): $(PIC_RELOBJFILES)
 	@mkdir -p $(ROOTDIR)/lib
 	$(LINK.c) -o $@ $(PIC_RELOBJFILES)
 
@@ -63,17 +62,17 @@ $(SODBGTARGET):	$(PIC_DBGOBJFILES)
 	@mkdir -p $(ROOTDIR)/lib
 	$(LINK.c) -o $@ $(PIC_DBGOBJFILES)
 
-$(DBGTARGET):	$(DBGOBJFILES)
+$(DBGTARGET): $(DBGOBJFILES)
 	@mkdir -p $(ROOTDIR)/lib
 	$(AR.c) $@ $(DBGOBJFILES)
 
-$(RELOBJFILES):	$(OUTPUT_DIR)/release/%.o: %.c $(HEADERS) | $(OUTPUT_DIR)
+$(RELOBJFILES): $(OUTPUT_DIR)/release/%.o: %.c $(HEADERS) | $(OUTPUT_DIR)
 	$(COMPILE.c) $(RELCFLAGS) -o $@ $<
 
 $(PIC_RELOBJFILES): $(OUTPUT_DIR)/release/%_PIC.o: %.c $(HEADERS) | $(OUTPUT_DIR)
 	$(COMPILE.c) -fPIC $(RELCFLAGS) -o $@ $<
 
-$(DBGOBJFILES):	$(OUTPUT_DIR)/debug/%.o: %.c $(HEADERS) | $(OUTPUT_DIR)
+$(DBGOBJFILES): $(OUTPUT_DIR)/debug/%.o: %.c $(HEADERS) | $(OUTPUT_DIR)
 	$(COMPILE.c) $(DBGCFLAGS) -o $@ $<
 
 $(PIC_DBGOBJFILES): $(OUTPUT_DIR)/debug/%_PIC.o: %.c $(HEADERS) | $(OUTPUT_DIR)

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,83 @@
-#
-# Just a minimal Makefile for now to install the most basic components
-#
-# Currently installs the assembler and the app loader library
-#
+include $(BUILD_DIR)/makefile.d/base.mk
+
+ROOTDIR = .
+TARGET = libpru-driver
+CROSS_COMPILE?=arm-linux-gnueabihf-
 PREFIX?=/usr/local
 
-all:
-	cd pru_sw/utils/pasm_source && ./linuxbuild
-	cd pru_sw/app_loader/interface && CROSS_COMPILE=$(CROSS_COMPILE) make
+CC = $(CROSS_COMPILE)gcc
+AR = $(CROSS_COMPILE)ar
 
-install:
-	install -m 0755 -d $(DESTDIR)$(PREFIX)/bin
-	install -m 0755 pru_sw/utils/pasm $(DESTDIR)$(PREFIX)/bin
-	cd pru_sw/app_loader/interface && CROSS_COMPILE=$(CROSS_COMPILE) make install
+INCLUDEDIR = ./pru_sw/app_loader/include
+
+C_FLAGS += -I. -Wall -I$(INCLUDEDIR)
+
+COMPILE.c = $(CC) $(C_FLAGS) $(CPP_FLAGS) -c
+AR.c	  = $(AR) rc
+LINK.c	  = $(CC) -shared
+
+DBGTARGET = $(OUTPUT_DIR)/$(TARGET)d.a
+RELTARGET = $(OUTPUT_DIR)/$(TARGET).a
+SODBGTARGET = $(OUTPUT_DIR)/$(TARGET)d.so
+SORELTARGET = $(OUTPUT_DIR)/$(TARGET).so
+
+DBGCFLAGS = -g -O0 -D__DEBUG
+RELCFLAGS = -O3 -mtune=cortex-a8 -march=armv7-a
+
+SOURCES = $(wildcard pru_sw/app_loader/interface/*.c)
+
+PUBLIC_HDRS = $(wildcard $(INCLUDEDIR)/*.h)
+PRIVATE_HDRS = $(wildcard *.h)
+HEADERS = $(PUBLIC_HDRS) $(PRIVATE_HDRS)
+
+DBGOBJFILES = $(SOURCES:%.c=$(OUTPUT_DIR)/debug/%.o)
+RELOBJFILES = $(SOURCES:%.c=$(OUTPUT_DIR)/release/%.o)
+PIC_DBGOBJFILES = $(SOURCES:%.c=$(OUTPUT_DIR)/debug/%_PIC.o)
+PIC_RELOBJFILES = $(SOURCES:%.c=$(OUTPUT_DIR)/release/%_PIC.o)
+
+.PHONY: clean debug release sodebug sorelease install
+
+all:	debug release sodebug sorelease
+
+release:	$(RELTARGET)
+
+sorelease:	$(SORELTARGET)
+
+sodebug:	$(SODBGTARGET)
+
+debug:		$(DBGTARGET)
+
+$(OUTPUT_DIR):
+	$(VERBOSE)mkdir -p $(OUTPUT_DIR)/release/pru_sw/app_loader/interface
+	$(VERBOSE)mkdir -p $(OUTPUT_DIR)/debug/pru_sw/app_loader/interface
+
+$(RELTARGET): $(RELOBJFILES)
+	@mkdir -p $(ROOTDIR)/lib
+	$(AR.c) $@ $(RELOBJFILES)
+
+$(SORELTARGET):	$(PIC_RELOBJFILES)
+	@mkdir -p $(ROOTDIR)/lib
+	$(LINK.c) -o $@ $(PIC_RELOBJFILES)
+
+$(SODBGTARGET):	$(PIC_DBGOBJFILES)
+	@mkdir -p $(ROOTDIR)/lib
+	$(LINK.c) -o $@ $(PIC_DBGOBJFILES)
+
+$(DBGTARGET):	$(DBGOBJFILES)
+	@mkdir -p $(ROOTDIR)/lib
+	$(AR.c) $@ $(DBGOBJFILES)
+
+$(RELOBJFILES):	$(OUTPUT_DIR)/release/%.o: %.c $(HEADERS) | $(OUTPUT_DIR)
+	$(COMPILE.c) $(RELCFLAGS) -o $@ $<
+
+$(PIC_RELOBJFILES): $(OUTPUT_DIR)/release/%_PIC.o: %.c $(HEADERS) | $(OUTPUT_DIR)
+	$(COMPILE.c) -fPIC $(RELCFLAGS) -o $@ $<
+
+$(DBGOBJFILES):	$(OUTPUT_DIR)/debug/%.o: %.c $(HEADERS) | $(OUTPUT_DIR)
+	$(COMPILE.c) $(DBGCFLAGS) -o $@ $<
+
+$(PIC_DBGOBJFILES): $(OUTPUT_DIR)/debug/%_PIC.o: %.c $(HEADERS) | $(OUTPUT_DIR)
+	$(COMPILE.c) -fPIC $(DBGCFLAGS) -o $@ $<
+
+clean:
+	-rm -rf *~ ./lib/* $(OUTPUT_DIR)


### PR DESCRIPTION
OK, shuffling a bunch of stuff around. But in the end, I forked a public repository for us for the beagleboard am335x_pru_package repository, but I really didn't like that name and renamed it pru-driver. We're only using a small portion of the repository, the driver itself, but it's fairly active, so I thought we might want to keep this fairly consistent with beagleboard to make rebases easier.

This is needed for an upcoming xl pull request.

Most of the Makefile is copied from https://github.com/beagleboard/am335x_pru_package/blob/master/pru_sw/app_loader/interface/Makefile. I just moved it to top level directory and changed it to be consistent with our common library building make system.
