### PR TITLE
DE3038: Silence some compiler warnings when building for bbb-release.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ AR = $(CROSS_COMPILE)ar
 
 INCLUDEDIR = ./pru_sw/app_loader/include
 
-C_FLAGS += -I. -Wall -I$(INCLUDEDIR)
+C_FLAGS += -I. -Wall -I$(INCLUDEDIR) -Wno-unused-result
 
 COMPILE.c = $(CC) $(C_FLAGS) $(CPP_FLAGS) -c
 AR.c = $(AR) rc


### PR DESCRIPTION
Defect [here](https://rally1.rallydev.com/#/3835160186d/detail/defect/45992807818), similar to [this `lua` PR](https://github.com/Vorne/lua/pull/7).

Before, doing a `bbb-release` build would get you a few lines like this:

```
pru_sw/app_loader/interface/prussdrv.c: In function ‘__prussdrv_memmap_init’:
pru_sw/app_loader/interface/prussdrv.c:83:13: warning: ignoring return value of ‘read’, declared with attribute warn_unused_result [-Wunused-result]
         read(fd, hexstring, PRUSS_UIO_PARAM_VAL_LEN);
             ^
```

Now it's all quiet.
