### PR TITLE
US2153, TA6780: Simplify PRU driver build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,27 +2,16 @@ BUILD_DIR ?= ../xl
 include $(BUILD_DIR)/makefile.d/base.mk
 
 ROOTDIR = .
-TARGET = libpru-driver
-CROSS_COMPILE ?= arm-linux-gnueabihf-
-
-CC = $(CROSS_COMPILE)gcc
-AR = $(CROSS_COMPILE)ar
 
 INCLUDEDIR = ./pru_sw/app_loader/include
 
-C_FLAGS += -I. -Wall -I$(INCLUDEDIR) -Wno-unused-result
+CFLAGS += -I. -I$(INCLUDEDIR) -Wall -Wno-unused-result
 
-COMPILE.c = $(CC) $(C_FLAGS) $(CPP_FLAGS) -c
+COMPILE.c = $(CC) $(CFLAGS) $(CPP_FLAGS) -c
 AR.c = $(AR) rc
 LINK.c = $(CC) -shared
 
-DBGTARGET = $(OUTPUT_DIR)/$(TARGET)d.a
-RELTARGET = $(OUTPUT_DIR)/$(TARGET).a
-SODBGTARGET = $(OUTPUT_DIR)/$(TARGET)d.so
-SORELTARGET = $(OUTPUT_DIR)/$(TARGET).so
-
-DBGCFLAGS = -g -O0 -D__DEBUG
-RELCFLAGS = -O3 -mtune=cortex-a8 -march=armv7-a
+DRIVER_A = $(OUTPUT_DIR)/libpru-driver.a
 
 SOURCES = $(wildcard pru_sw/app_loader/interface/*.c)
 
@@ -30,54 +19,21 @@ PUBLIC_HDRS = $(wildcard $(INCLUDEDIR)/*.h)
 PRIVATE_HDRS = $(wildcard *.h)
 HEADERS = $(PUBLIC_HDRS) $(PRIVATE_HDRS)
 
-DBGOBJFILES = $(SOURCES:%.c=$(OUTPUT_DIR)/debug/%.o)
-RELOBJFILES = $(SOURCES:%.c=$(OUTPUT_DIR)/release/%.o)
-PIC_DBGOBJFILES = $(SOURCES:%.c=$(OUTPUT_DIR)/debug/%_PIC.o)
-PIC_RELOBJFILES = $(SOURCES:%.c=$(OUTPUT_DIR)/release/%_PIC.o)
+OBJS = $(SOURCES:%.c=$(OUTPUT_DIR)/%.o)
 
-.PHONY: clean debug release sodebug sorelease install
-
-all: debug release sodebug sorelease
-
-release: $(RELTARGET)
-
-sorelease: $(SORELTARGET)
-
-sodebug: $(SODBGTARGET)
-
-debug: $(DBGTARGET)
+all: $(DRIVER_A)
 
 $(OUTPUT_DIR):
-	$(VERBOSE)mkdir -p $(OUTPUT_DIR)/release/pru_sw/app_loader/interface
-	$(VERBOSE)mkdir -p $(OUTPUT_DIR)/debug/pru_sw/app_loader/interface
+	$(VERBOSE)mkdir -p $(OUTPUT_DIR)/pru_sw/app_loader/interface
 
-$(RELTARGET): $(RELOBJFILES)
+$(DRIVER_A): $(OBJS)
 	@mkdir -p $(ROOTDIR)/lib
-	$(AR.c) $@ $(RELOBJFILES)
+	@echo $(AR) src $@ $(OBJS)
+	@echo OBJS: $(OBJS)
+	$(AR) src $@ $(OBJS)
 
-$(SORELTARGET): $(PIC_RELOBJFILES)
-	@mkdir -p $(ROOTDIR)/lib
-	$(LINK.c) -o $@ $(PIC_RELOBJFILES)
-
-$(SODBGTARGET):	$(PIC_DBGOBJFILES)
-	@mkdir -p $(ROOTDIR)/lib
-	$(LINK.c) -o $@ $(PIC_DBGOBJFILES)
-
-$(DBGTARGET): $(DBGOBJFILES)
-	@mkdir -p $(ROOTDIR)/lib
-	$(AR.c) $@ $(DBGOBJFILES)
-
-$(RELOBJFILES): $(OUTPUT_DIR)/release/%.o: %.c $(HEADERS) | $(OUTPUT_DIR)
-	$(COMPILE.c) $(RELCFLAGS) -o $@ $<
-
-$(PIC_RELOBJFILES): $(OUTPUT_DIR)/release/%_PIC.o: %.c $(HEADERS) | $(OUTPUT_DIR)
-	$(COMPILE.c) -fPIC $(RELCFLAGS) -o $@ $<
-
-$(DBGOBJFILES): $(OUTPUT_DIR)/debug/%.o: %.c $(HEADERS) | $(OUTPUT_DIR)
-	$(COMPILE.c) $(DBGCFLAGS) -o $@ $<
-
-$(PIC_DBGOBJFILES): $(OUTPUT_DIR)/debug/%_PIC.o: %.c $(HEADERS) | $(OUTPUT_DIR)
-	$(COMPILE.c) -fPIC $(DBGCFLAGS) -o $@ $<
+$(OBJS): $(OUTPUT_DIR)/%.o: %.c $(HEADERS) | $(OUTPUT_DIR)
+	$(CC) $(CFLAGS) $(PROFILE_FLAGS) -c $< -o $@
 
 clean:
 	-rm -rf *~ ./lib/* $(OUTPUT_DIR)


### PR DESCRIPTION
Explicitly overriding `CC` and `AR` here was causing problems with bitbake. While I was at it, I don't believe we were using the shared objects, so it was easier to just get rid of those than figure out the changes needed for them.

For reference, this file now looks much more like the make file for Jansson, so there is some consistency between libraries.

https://github.com/Vorne/meta-vorne/pull/24 depends on these changes.