### PR TITLE
US2163, TA6868: Don't depend on xl repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-BUILD_DIR ?= ../xl
-include $(BUILD_DIR)/makefile.d/base.mk
+BUILD_TAG ?= bbb-release
+OUTPUT_DIR = build/$(BUILD_TAG)
 
 ROOTDIR = .
 


### PR DESCRIPTION
The only thing I can see that the pru-driver `Makefile` needed out of `base.mk` was the output directory. I don't see any harm explicitly setting that so that this repo doesn't rely on `xl`.