### PR TITLE
US2187, TA7057: Allow OUTPUT_DIR to be externally specified

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BUILD_TAG ?= bbb-release
-OUTPUT_DIR = build/$(BUILD_TAG)
+OUTPUT_DIR ?= build/$(BUILD_TAG)
 
 ROOTDIR = .
 


### PR DESCRIPTION
For HD builds the directory is instead `build/$(BUILD_TAG)-hd`