### PR TITLE
US2231, TA7590: Allow xl build finer grain control of library output directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 BUILD_TAG ?= bbb-release
-OUTPUT_DIR ?= build/$(BUILD_TAG)
+include $(BUILD_DIR)/makefile.d/base.mk
+
+# Fall back to OUTPUT_DIR. Keeps this build working if there is a mismatch with the xl repo.
+LIBRARY_OUTPUT_DIR ?= $(OUTPUT_DIR)
 
 ROOTDIR = .
 
@@ -11,7 +14,7 @@ COMPILE.c = $(CC) $(CFLAGS) $(CPP_FLAGS) -c
 AR.c = $(AR) rc
 LINK.c = $(CC) -shared
 
-DRIVER_A = $(OUTPUT_DIR)/libpru-driver.a
+DRIVER_A = $(LIBRARY_OUTPUT_DIR)/libpru-driver.a
 
 SOURCES = $(wildcard pru_sw/app_loader/interface/*.c)
 
@@ -19,12 +22,12 @@ PUBLIC_HDRS = $(wildcard $(INCLUDEDIR)/*.h)
 PRIVATE_HDRS = $(wildcard *.h)
 HEADERS = $(PUBLIC_HDRS) $(PRIVATE_HDRS)
 
-OBJS = $(SOURCES:%.c=$(OUTPUT_DIR)/%.o)
+OBJS = $(SOURCES:%.c=$(LIBRARY_OUTPUT_DIR)/%.o)
 
 all: $(DRIVER_A)
 
-$(OUTPUT_DIR):
-	$(VERBOSE)mkdir -p $(OUTPUT_DIR)/pru_sw/app_loader/interface
+$(LIBRARY_OUTPUT_DIR):
+	$(VERBOSE)mkdir -p $(LIBRARY_OUTPUT_DIR)/pru_sw/app_loader/interface
 
 $(DRIVER_A): $(OBJS)
 	@mkdir -p $(ROOTDIR)/lib
@@ -32,8 +35,8 @@ $(DRIVER_A): $(OBJS)
 	@echo OBJS: $(OBJS)
 	$(AR) src $@ $(OBJS)
 
-$(OBJS): $(OUTPUT_DIR)/%.o: %.c $(HEADERS) | $(OUTPUT_DIR)
+$(OBJS): $(LIBRARY_OUTPUT_DIR)/%.o: %.c $(HEADERS) | $(LIBRARY_OUTPUT_DIR)
 	$(CC) $(CFLAGS) $(PROFILE_FLAGS) -c $< -o $@
 
 clean:
-	-rm -rf *~ ./lib/* $(OUTPUT_DIR)
+	-rm -rf *~ ./lib/* $(LIBRARY_OUTPUT_DIR)


### PR DESCRIPTION
Last one.

In order for our xl SQL functions to be compiled into a shared library, we need to compile all files with `-fPIC` (Position Independent Code), including libraries such as this. However, PIC has performance impacts, so we don't want to always compile with `-fPIC`. So, we want to be able to compile two versions of our libraries, those to be included in the xl process and those to be included in shared objects.

I added a fall-back mechanism here, so this can be merged ahead of the XL changes.